### PR TITLE
Reset the sidebar scroll when mode changes. Preserve the position from

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TODO: Document all of these
 
 - setting things in config
   - map store
+  - sidebarDiv store
   - ownership of gjSchemeCollection and initialization gotchas
 - govuk
 - static assets

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,6 +11,7 @@ import type { Map } from "maplibre-gl";
 
 // TODO Still do this, or use something else?
 export let map: Writable<Map | null> = writable(null);
+export let sidebarDiv: Writable<HTMLDivElement | null> = writable(null);
 
 // The draw code should be agnostic to the feature properties that differ by
 // schema. Start centralizing the logic here, so it's easy for other users to

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="F, S">
   import { circleRadius, colors, lineWidth } from "$lib/draw/colors";
   import type { Feature } from "geojson";
-  import { hideSchemes, mode } from "$lib/draw/stores";
+  import { hideSchemes, mode, preserveListScroll } from "$lib/draw/stores";
   import {
     addLineStringEndpoints,
     constructMatchExpression,
@@ -10,7 +10,7 @@
     isPolygon,
     layerId,
   } from "$lib/maplibre";
-  import { type Config, map } from "$lib/config";
+  import { type Config, map, sidebarDiv } from "$lib/config";
   import type {
     DataDrivenPropertyValueSpecification,
     ExpressionSpecification,
@@ -101,6 +101,8 @@
     }
     // TODO Possible to be missing?
     if (e.detail.features[0]) {
+      $preserveListScroll = $sidebarDiv ? $sidebarDiv.scrollTop : 0;
+
       // We just clicked a feature, so the cursor would've been different
       $map.getCanvas().style.cursor = "inherit";
       mode.set({ mode: "edit-form", id: e.detail.features[0].id as number });

--- a/src/lib/draw/stores.ts
+++ b/src/lib/draw/stores.ts
@@ -23,6 +23,10 @@ export const sidebarHover: Writable<number | null> = writable(null);
 
 export const mode: Writable<Mode> = writable({ mode: "list" });
 
+// When leaving list mode in some cases, remember the scroll position to later
+// restore it.
+export const preserveListScroll: Writable<number> = writable(0);
+
 // All feature IDs must:
 //
 // - be unique

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -5,6 +5,7 @@
     mode,
     sidebarHover,
     emptySchemes,
+    preserveListScroll,
   } from "$lib/draw/stores";
   import {
     ButtonGroup,
@@ -15,7 +16,7 @@
     WarningButton,
   } from "govuk-svelte";
   import { bbox } from "$lib/maplibre";
-  import { map, type Config } from "$lib/config";
+  import { map, sidebarDiv, type Config } from "$lib/config";
   import { onDestroy } from "svelte";
   import deleteIcon from "$lib/assets/delete.svg?url";
   import type { Schemes } from "$lib/draw/types";
@@ -60,6 +61,8 @@
         duration: 500,
       });
     }
+
+    $preserveListScroll = $sidebarDiv ? $sidebarDiv.scrollTop : 0;
 
     mode.set({ mode: "edit-form", id });
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { MapLibre } from "svelte-maplibre";
   import type { Map } from "maplibre-gl";
-  import { type Config, map } from "$lib/config";
+  import { type Config, map, sidebarDiv } from "$lib/config";
   import ImageLayer from "$lib/draw/image/ImageLayer.svelte";
   import InterventionLayer from "$lib/draw/InterventionLayer.svelte";
   import PolygonToolLayer from "$lib/draw/polygon/PolygonToolLayer.svelte";
@@ -133,7 +133,7 @@
 </script>
 
 <div style="display: flex; height: 100vh">
-  <div class="sidebar">
+  <div class="sidebar" bind:this={$sidebarDiv}>
     <PerModeControls {cfg} {gjSchemes} {routeSnapperUrl} />
   </div>
   <div class="map">


### PR DESCRIPTION
list mode.

Before: https://acteng.github.io/atip/scheme.html?authority=LAD_Adur&schema=pipeline
After: https://acteng.github.io/atip/fix_sidebar_scrolling/scheme.html?authority=LAD_Adur&schema=pipeline

Create a few interventions if needed. The list mode should need scrolling to see some of them. Scroll down and select one in the list or map. Before, the form opened up would start towards the bottom (depending how much you scrolled in list mode), and when returning to list mode, it usually resets to the top (if you scrolled up in the form to click save).

After, the scroll position is always reset to the top for opening new modes. When returning to list mode, it tries to preserve the scroll position from when you last selected an intervention (whether on the map or sidebar).

This was a complaint from LCWIP mappers, who had very very long sidebars and would lose their place when filling out the form one-by-one.