### PR TITLE
Default to adjusting points when editing an existing route

### DIFF
--- a/src/lib/draw/EditMode.svelte
+++ b/src/lib/draw/EditMode.svelte
@@ -209,7 +209,7 @@
 {#if controls == "point"}
   <PointControls {finish} {cancel} />
 {:else if controls == "route"}
-  <RouteControls finish={finishRoute} {cancel} />
+  <RouteControls finish={finishRoute} {cancel} editingExisting />
 {:else if controls == "area"}
   <AreaControls finish={finishArea} {cancel} />
 {/if}

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -22,6 +22,7 @@
 
   export let finish: () => void;
   export let cancel: () => void;
+  export let editingExisting: boolean;
 
   onDestroy(() => {
     $waypoints = [];
@@ -31,7 +32,9 @@
     }
   });
 
-  let drawMode: "append-start" | "append-end" | "adjust" = "append-end";
+  let drawMode: "append-start" | "append-end" | "adjust" = editingExisting
+    ? "adjust"
+    : "append-end";
   let snapMode = true;
   let undoStates: Waypoint[][] = [];
 

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -60,4 +60,4 @@
   }
 </script>
 
-<RouteControls {finish} cancel={onFailure} />
+<RouteControls {finish} cancel={onFailure} editingExisting={false} />


### PR DESCRIPTION
A common case of editing a route is just to adjust the shape or fill out the form. Having the preview line chase the cursor by default feels very annoying to me. Previously we had this behavior because it wasn't clear how to switch between the 3 modes, but now it should be much easier (and there are the keybindings too), so I'm proposing we change this default.