### PR TITLE
Prevent users from accidentally throwing away edits, by making the Es…

### DIFF
--- a/src/lib/draw/area/AreaControls.svelte
+++ b/src/lib/draw/area/AreaControls.svelte
@@ -222,14 +222,24 @@
     let tag = (e.target as HTMLElement).tagName;
     let formFocused = tag == "INPUT" || tag == "TEXTAREA";
 
-    if (e.key === "Enter" && !formFocused) {
+    if (e.key == "Enter" && !formFocused) {
       e.stopPropagation();
       if ($waypoints.length >= 3) {
         finish();
+      } else {
+        window.alert(
+          "You can't save this area unless it has at least three points. Press 'Cancel' to discard these changes.",
+        );
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key == "Escape") {
       e.stopPropagation();
-      cancel();
+      if ($waypoints.length >= 3) {
+        finish();
+      } else {
+        window.alert(
+          "You can't save this area unless it has at least three points. Press 'Cancel' to discard these changes.",
+        );
+      }
     } else if (e.key == "s" && !formFocused) {
       toggleSnap();
     } else if (e.key == "z" && e.ctrlKey) {
@@ -315,11 +325,9 @@
           </li>
           <li>
             <b>Enter</b>
-            to finish
-          </li>
-          <li>
+            or
             <b>Escape</b>
-            to cancel
+            to finish
           </li>
         </ul>
       </HelpButton>

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -33,9 +33,15 @@
   }
 
   function keyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
+    if (e.key == "Escape") {
       e.stopPropagation();
-      cancel();
+      if ($pointPosition) {
+        finish();
+      } else {
+        window.alert(
+          "You can't save this point until you place it on the map. Press 'Cancel' to discard these changes.",
+        );
+      }
     }
   }
 </script>

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -228,14 +228,24 @@
     let tag = (e.target as HTMLElement).tagName;
     let formFocused = tag == "INPUT" || tag == "TEXTAREA";
 
-    if (e.key === "Enter" && !formFocused) {
+    if (e.key == "Enter" && !formFocused) {
       e.stopPropagation();
       if ($waypoints.length >= 2) {
         finish();
+      } else {
+        window.alert(
+          "You can't save this route unless it has at least two points. Press 'Cancel' to discard these changes.",
+        );
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key == "Escape") {
       e.stopPropagation();
-      cancel();
+      if ($waypoints.length >= 2) {
+        finish();
+      } else {
+        window.alert(
+          "You can't save this route unless it has at least two points. Press 'Cancel' to discard these changes.",
+        );
+      }
     } else if (e.key == "s" && !formFocused) {
       toggleSnap();
     } else if (e.key == "1" && !formFocused) {
@@ -344,11 +354,9 @@
           </li>
           <li>
             <b>Enter</b>
-            to finish
-          </li>
-          <li>
+            or
             <b>Escape</b>
-            to cancel
+            to finish
           </li>
         </ul>
       </HelpButton>


### PR DESCRIPTION
…cape key also finish, not cancel

I'm not sure this is a good change though. Sometimes I legitimately find myself pressing escape because I want to cancel and throw away what I'm doing. But when I'm editing a form, I instinctively press it and want to save. Thoughts?